### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server for creating and managing [Dub.co](https://dub.co) short links (unofficial). This server enables AI assistants to create, update, and delete short links through the Dub.co API.
 
+<a href="https://glama.ai/mcp/servers/0tvsbwmk8m">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/0tvsbwmk8m/badge" alt="Unofficial dubco-mcp-server MCP server" />
+</a>
+
 ## 🚀 Features
 
 - Create custom short links with your Dub.co domains


### PR DESCRIPTION
This PR adds a badge for the [Unofficial dubco-mcp-server](https://glama.ai/mcp/servers/0tvsbwmk8m) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0tvsbwmk8m">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/0tvsbwmk8m/badge" alt="Unofficial dubco-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.